### PR TITLE
Fail CI if cargo lockfile is not up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: swatinem/rust-cache@v2
       - name: cargo-check
-        run: cargo check
+        run: cargo check --locked
 
   fmt:
     name: format


### PR DESCRIPTION
This should fail the CI if the `Cargo.lock` is not up-to-date.

This means the CI run for this should now fail, I will rebase this PR after #15 is merged to make CI green then.