### PR TITLE
Renames device.rs device_state_changed signal to PascalCase

### DIFF
--- a/src/network_manager/device.rs
+++ b/src/network_manager/device.rs
@@ -64,7 +64,7 @@ pub(crate) trait Device {
     ) -> zbus::Result<()>;
 
     /// StateChanged signal
-    #[zbus(signal, name = "state_changed")]
+    #[zbus(signal, name = "StateChanged")]
     fn device_state_changed(&self, new_state: u32, old_state: u32, reason: u32)
         -> zbus::Result<()>;
 


### PR DESCRIPTION
Snake case doesn't work, renaming it to PascalCase does.

There might be other cases and I guess that the "name" attribute has to match the original name as stated in the documentation: https://people.freedesktop.org/~lkundrak/nm-docs/gdbus-org.freedesktop.NetworkManager.Device.html