### PR TITLE
Fix `list_access_points` and `wifi_access_points` examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "list_access_points"
+version = "0.1.0"
+dependencies = [
+ "rusty_network_manager",
+ "tokio",
+ "tokio-stream",
+ "zbus",
+]
+
+[[package]]
 name = "list_devices"
 version = "0.1.0"
 dependencies = [
@@ -1106,6 +1116,16 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wifi_access_points"
+version = "0.1.0"
+dependencies = [
+ "rusty_network_manager",
+ "tokio",
+ "tokio-stream",
+ "zbus",
+]
 
 [[package]]
 name = "wifi_active_ap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [workspace]
 members = [
+    "examples/list_access_points",
     "examples/list_devices",
     "examples/show_wifi_networks",
     "examples/simple",
+    "examples/wifi_access_points",
     "examples/wifi_active_ap",
     "examples/wifi_info",
 ]

--- a/examples/list_access_points/src/main.rs
+++ b/examples/list_access_points/src/main.rs
@@ -1,6 +1,6 @@
+use rusty_network_manager::{AccessPointProxy, NetworkManagerProxy, WirelessProxy};
 use std::collections::HashMap;
 use tokio_stream::StreamExt;
-use rusty_network_manager::{NetworkManagerProxy, WirelessProxy, AccessPointProxy};
 use zbus::Connection;
 
 #[tokio::main]
@@ -20,26 +20,32 @@ async fn main() {
                 .expect("Unable to get wireless proxy");
 
             let options = HashMap::new();
-            wireless_proxy.request_scan(options).await.expect("Could not request scan, try running as sudo.");
+            wireless_proxy
+                .request_scan(options)
+                .await
+                .expect("Could not request scan, try running as sudo.");
 
-            let mut access_points_changed = wireless_proxy.receive_access_point_added().await.expect("We got here!");
+            let mut access_points_changed = wireless_proxy
+                .receive_access_point_added()
+                .await
+                .expect("We got here!");
             while let Some(v) = access_points_changed.next().await {
                 println!("{}", v.message());
             }
 
             // Get notified when scan is complete
             let mut scan_changed = wireless_proxy.receive_last_scan_changed().await;
-            
+
             let mut count = 0;
             while let Some(v) = scan_changed.next().await {
                 println!("{}", v.name());
                 println!("scan changed: {:?}", v.get().await);
                 count += 1;
                 if count >= 2 {
-                  //  break;
+                    //  break;
                 }
             }
-            
+
             let access_points = wireless_proxy.get_all_access_points().await;
             //println!("AccessPoints: {:?}", access_points);
             for access_point_path in access_points.unwrap() {
@@ -56,9 +62,14 @@ async fn main() {
                     continue;
                 }
 
-                println!("Access Point: {}\n\tFrequency: {:?}\n\tAddress: {}", ssid_string, frequency.unwrap(), hw_address.unwrap());
+                println!(
+                    "Access Point: {}\n\tFrequency: {:?}\n\tAddress: {}",
+                    ssid_string,
+                    frequency.unwrap(),
+                    hw_address.unwrap()
+                );
             }
-        },
+        }
         Err(_) => println!("No access points found"),
     };
 }

--- a/examples/list_access_points/src/main.rs
+++ b/examples/list_access_points/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use tokio_stream::StreamExt;
-use network_manager::{Connection, NetworkManagerProxy, WirelessProxy, AccessPointProxy};
+use rusty_network_manager::{NetworkManagerProxy, WirelessProxy, AccessPointProxy};
+use zbus::Connection;
 
 #[tokio::main]
 async fn main() {

--- a/examples/wifi_access_points/src/main.rs
+++ b/examples/wifi_access_points/src/main.rs
@@ -1,24 +1,22 @@
 //! # wifi_access_points Example
-//! 
+//!
 //! Rust example that displays the all the access points that an interface can see.
 //! Usage: ./wifi_access_points <ifname>
 //!
 //! Example: ./wifi_access_points wlan0
 //!
 //! DISCLAIMER:
-//! The example code provided here is for illustrative purposes only. It is provided "AS IS", 
-//! without warranty of any kind, express or implied, including but not limited to the warranties of 
-//! merchantability, fitness for a particular purpose, and non-infringement. In no event shall the authors 
-//! or copyright holders be liable for any claim, damages, or other liability, whether in an action of 
-//! contract, tort, or otherwise, arising from, out of, or in connection with the example code or 
+//! The example code provided here is for illustrative purposes only. It is provided "AS IS",
+//! without warranty of any kind, express or implied, including but not limited to the warranties of
+//! merchantability, fitness for a particular purpose, and non-infringement. In no event shall the authors
+//! or copyright holders be liable for any claim, damages, or other liability, whether in an action of
+//! contract, tort, or otherwise, arising from, out of, or in connection with the example code or
 //! the use or other dealings in the example code.
 
-use std::env;
-use std::sync::Mutex;
+use rusty_network_manager::{AccessPointProxy, NetworkManagerProxy, WirelessProxy};
 use std::collections::HashMap;
 use tokio_stream::StreamExt;
-use rusty_network_manager::{NetworkManagerProxy, WirelessProxy, AccessPointProxy};
-use zbus::{Connection, proxy::PropertyChanged};
+use zbus::Connection;
 
 #[tokio::main]
 async fn main() {
@@ -30,15 +28,16 @@ async fn main() {
         .await
         .expect("Could not get NetworkManager");
 
-    let wireless_interface_path = nm.get_device_by_ip_iface("wlan0")
+    let wireless_interface_path = nm
+        .get_device_by_ip_iface("wlan0")
         .await
         .expect("Could not get wireless interface");
 
     let wireless_proxy = WirelessProxy::new_from_path(wireless_interface_path, &connection)
         .await
         .expect("Could not get wireless device");
-    
-    tokio::join!{
+
+    tokio::join! {
         monitor_add_access_point(&wireless_proxy, &connection),
         monitor_remove_access_point(&wireless_proxy, &connection),
         request_scan(&wireless_proxy)
@@ -46,42 +45,49 @@ async fn main() {
 }
 
 async fn request_scan(wireless_proxy: &WirelessProxy<'_>) {
-    let last_scan = wireless_proxy.last_scan().await;
+    let _last_scan = wireless_proxy.last_scan().await;
 
     tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
     let options = HashMap::new();
-    wireless_proxy.request_scan(options).await.expect("Could not request scan, try running as sudo.");
+    wireless_proxy
+        .request_scan(options)
+        .await
+        .expect("Could not request scan, try running as sudo.");
     println!("Scanning for access points");
 }
 
 async fn monitor_add_access_point(wireless_proxy: &WirelessProxy<'_>, connection: &Connection) {
     println!("Monitoring for new APs");
-    let mut access_points_changed = wireless_proxy.receive_access_point_added().await.expect("We got here!");
+    let mut access_points_changed = wireless_proxy
+        .receive_access_point_added()
+        .await
+        .expect("We got here!");
     while let Some(v) = access_points_changed.next().await {
         let args = v.args().unwrap();
 
-        let owned_object_path = zbus::zvariant::OwnedObjectPath::try_from(args.access_point);
+        let owned_object_path = zbus::zvariant::OwnedObjectPath::from(args.access_point);
 
-        let access_point = AccessPointProxy::new_from_path(owned_object_path.unwrap(), connection)
+        let access_point = AccessPointProxy::new_from_path(owned_object_path, connection)
             .await
             .expect("Could not get access point");
 
         let ssid = String::from_utf8(access_point.ssid().await.unwrap());
-        let msg = v.message();
-        let path  = msg.header().member().unwrap();
         println!("+ {} {:?}", ssid.unwrap(), v.message());
     }
 }
 
 async fn monitor_remove_access_point(wireless_proxy: &WirelessProxy<'_>, connection: &Connection) {
     println!("Monitoring for removed APs");
-    let mut access_points_changed = wireless_proxy.receive_access_point_removed().await.expect("We got here!");
+    let mut access_points_changed = wireless_proxy
+        .receive_access_point_removed()
+        .await
+        .expect("We got here!");
     while let Some(v) = access_points_changed.next().await {
         let args = v.args().unwrap();
 
-        let owned_object_path = zbus::zvariant::OwnedObjectPath::try_from(args.access_point);
+        let owned_object_path = zbus::zvariant::OwnedObjectPath::from(args.access_point);
 
-        let access_point = AccessPointProxy::new_from_path(owned_object_path.unwrap(), connection)
+        let access_point = AccessPointProxy::new_from_path(owned_object_path, connection)
             .await
             .expect("Could not get access point");
 

--- a/examples/wifi_access_points/src/main.rs
+++ b/examples/wifi_access_points/src/main.rs
@@ -17,8 +17,8 @@ use std::env;
 use std::sync::Mutex;
 use std::collections::HashMap;
 use tokio_stream::StreamExt;
-use network_manager::{Connection, NetworkManagerProxy, WirelessProxy, AccessPointProxy};
-use zbus::proxy::PropertyChanged;
+use rusty_network_manager::{NetworkManagerProxy, WirelessProxy, AccessPointProxy};
+use zbus::{Connection, proxy::PropertyChanged};
 
 #[tokio::main]
 async fn main() {
@@ -47,7 +47,6 @@ async fn main() {
 
 async fn request_scan(wireless_proxy: &WirelessProxy<'_>) {
     let last_scan = wireless_proxy.last_scan().await;
-
 
     tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
     let options = HashMap::new();


### PR DESCRIPTION
Fix some non-compiling examples and run `clippy` and `rustfmt` on them. 

Note: I have https://github.com/abezukor/rusty_network_manager/pull/1 making further improvements on top of this PR. Let me know if i should merge them into 1 PR.