### PR TITLE
README: Remove `zbus` from prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ through NetworkManager.
 Before you can use this project, ensure you have the following installed:
 - Rust and Cargo (latest stable version recommended)
 - NetworkManager on your Linux distribution
-- zbus
 
 ## Installation
 


### PR DESCRIPTION
Since the project is using Cargo, zbus is automatically downloaded, built and linked and hence users don't need to care about it being a prerequisite, just like other dependencies. :)