### PR TITLE
Remove references for values when updating settings

### DIFF
--- a/src/network_manager/settings_connection.rs
+++ b/src/network_manager/settings_connection.rs
@@ -68,7 +68,7 @@ trait SettingsConnection {
         &self,
         properties: std::collections::HashMap<
             &str,
-            std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
+            std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
         >,
     ) -> zbus::Result<()>;
 
@@ -77,10 +77,10 @@ trait SettingsConnection {
         &self,
         settings: std::collections::HashMap<
             &str,
-            std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
+            std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
         >,
         flags: u32,
-        args: std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
+        args: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
     ) -> zbus::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>;
 
     /// UpdateUnsaved method
@@ -88,7 +88,7 @@ trait SettingsConnection {
         &self,
         properties: std::collections::HashMap<
             &str,
-            std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
+            std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
         >,
     ) -> zbus::Result<()>;
 


### PR DESCRIPTION
Makes the process much more ergonomic since `HashMap<&str, HashMap<&str, &Value>>` cannot be constructed directly due to the references (unless I'm missing something crucial).

Currently the process is as follows:
```Rust
// Get current settings
let settings = proxy.get_settings().await?;

// Create owned values
let mut owned_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
for (k, v) in settings {
    let mut inner = HashMap::new();
    for (k2, v2) in v {
        inner.insert(k2.clone(), Value::try_from(v2)?);
    }
    owned_map.insert(k.clone(), inner);
}

// Update settings with whatever here
// owned_map.insert(...)

// Construct hashmap with referenced values
let mut borrowed: HashMap<&str, HashMap<&str, &Value>> = HashMap::new();
for (k, v) in &owned_map {
    let mut inner = HashMap::new();
    for (k2, v2) in v {
        inner.insert(k2.as_str(), v2);
    }
    result.insert(k.as_str(), inner);
}

proxy.update(borrowed).await?;
```

The new process would be:

```Rust
let settings = proxy.get_settings().await?;
let mut new_settings: HashMap<&str, HashMap<&str, Value<'_>>> = HashMap::new();
for (k, v) in &settings {
    let mut inner = HashMap::new();
    for (k2, v2) in v {
        inner.insert(k2.as_str(), Value::try_from(v2)?);
    }
    new_settings.insert(k.as_str(), inner);
}

// new_settings.insert(...)

proxy.update(new_settings).await?;
```